### PR TITLE
Delete reverts saveable

### DIFF
--- a/app/javascript/react/components/IndexContent/IndexContent.js
+++ b/app/javascript/react/components/IndexContent/IndexContent.js
@@ -89,6 +89,7 @@ const IndexContent = props => {
         setDeleteClickedIndex={setDeleteClickedIndex}
         getDeleteTitleClicked={getDeleteTitleClicked}
         deleteTabByIndex={deleteTabByIndex}
+        setSaveable={setSaveable}
       />
     </>
   )

--- a/app/javascript/react/components/IndexContent/IndexContent.js
+++ b/app/javascript/react/components/IndexContent/IndexContent.js
@@ -89,6 +89,7 @@ const IndexContent = props => {
         setDeleteClickedIndex={setDeleteClickedIndex}
         getDeleteTitleClicked={getDeleteTitleClicked}
         deleteTabByIndex={deleteTabByIndex}
+        saveable={saveable}
         setSaveable={setSaveable}
       />
     </>

--- a/app/javascript/react/components/UI/ModalDeleteTab.js
+++ b/app/javascript/react/components/UI/ModalDeleteTab.js
@@ -7,6 +7,7 @@ const ModalDeleteTab = (props) => {
     setDeleteClickedIndex,
     getDeleteTitleClicked,
     deleteTabByIndex,
+    saveable,
     setSaveable
   } = props
 
@@ -20,11 +21,13 @@ const ModalDeleteTab = (props) => {
   }
 
   const showModal = () => deleteClickedIndex !== null
+  const unsavedWarning = saveable ? "You have unsaved changes in the tab editor which will be lost.\n" : null
 
   return (
     <>
       <Modal show={showModal()} onHide={handleCancel}>
         <Modal.Body>
+          {unsavedWarning}
           Are you sure you want to delete '{getDeleteTitleClicked()}'?
         </Modal.Body>
         <Modal.Footer className="modal-button-area">

--- a/app/javascript/react/components/UI/ModalDeleteTab.js
+++ b/app/javascript/react/components/UI/ModalDeleteTab.js
@@ -6,11 +6,13 @@ const ModalDeleteTab = (props) => {
     deleteClickedIndex,
     setDeleteClickedIndex,
     getDeleteTitleClicked,
-    deleteTabByIndex
+    deleteTabByIndex,
+    setSaveable
   } = props
 
   const handleConfirm = () => {
     deleteTabByIndex(deleteClickedIndex)
+    setSaveable(false)
     setDeleteClickedIndex(null)
   }
   const handleCancel = () => {


### PR DESCRIPTION
bug fix: deleting a tab now reverts saveability in tab editor to 'false'